### PR TITLE
Fix deprecation warnings on 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
+Compat 0.9.5
 Nettle
 Requests 0.3.7

--- a/examples/echo.jl
+++ b/examples/echo.jl
@@ -1,6 +1,8 @@
 # Example of DandelionWebSocket.jl:
 # Send some text and binary frames to ws://echo.websocket.org, which echoes them back.
 
+using Compat
+import Compat: String
 using DandelionWebSockets
 import Requests: URI
 
@@ -16,7 +18,7 @@ type EchoHandler <: WebSocketHandler
 end
 
 # These are called when you get text/binary frames, respectively.
-on_text(::EchoHandler, s::UTF8String)         = println("Received text: $s")
+on_text(::EchoHandler, s::Compat.UTF8String)  = println("Received text: $s")
 on_binary(::EchoHandler, data::Vector{UInt8}) = println("Received data: $data")
 
 # These are called when the WebSocket state changes.
@@ -30,7 +32,7 @@ function state_open(handler::EchoHandler)
 
     # Send some text frames, and a binary frame.
     @schedule begin
-        texts = [utf8("Hello"), utf8("world"), utf8("!")]
+        texts = [String("Hello"), String("world"), String("!")]
 
         for text in texts
             println("Sending  text: $text")

--- a/src/DandelionWebSockets.jl
+++ b/src/DandelionWebSockets.jl
@@ -1,5 +1,7 @@
 module DandelionWebSockets
 
+using Compat
+
 export AbstractWSClient,
        WSClient,
        stop,
@@ -22,7 +24,7 @@ abstract AbstractWSClient
 abstract WebSocketHandler
 
 "Handle a text frame."
-on_text(t::WebSocketHandler, ::UTF8String) = nothing
+on_text(t::WebSocketHandler, ::Compat.UTF8String) = nothing
 
 "Handle a binary frame."
 on_binary(t::WebSocketHandler, ::Vector{UInt8}) = nothing

--- a/src/client.jl
+++ b/src/client.jl
@@ -1,6 +1,7 @@
 import Requests: URI
 import Base: show
 using BufferedStreams
+using Compat
 
 # These proxies glue the different coroutines together. For isntance, `ClientLogic` calls callback
 # function such as `on_text` and `state_closing` on the proxy, which is then called on the callback
@@ -144,7 +145,7 @@ end
 stop(c::WSClient) = handle(c.logic_proxy, CloseRequest())
 
 "Send a single text frame."
-send_text(c::WSClient, s::UTF8String) = handle(c.logic_proxy, SendTextFrame(s, true, OPCODE_TEXT))
+send_text(c::WSClient, s::Compat.UTF8String) = handle(c.logic_proxy, SendTextFrame(s, true, OPCODE_TEXT))
 
 "Send a single binary frame."
 send_binary(c::WSClient, data::Vector{UInt8}) =

--- a/src/client_logic.jl
+++ b/src/client_logic.jl
@@ -14,6 +14,8 @@
 # test the logic of the WebSocket synchronously, without any asynchronicity or concurrency
 # complicating things.
 
+using Compat
+import Compat: String
 export ClientLogic
 
 #
@@ -29,7 +31,7 @@ abstract ClientLogicInput
 
 "Send a text frame, sent to `ClientLogic`."
 immutable SendTextFrame <: ClientLogicInput
-	data::UTF8String
+	data::Compat.UTF8String
 	# True if this is the final frame in the text message.
 	isfinal::Bool
 	# What WebSocket opcode should be used.
@@ -227,7 +229,7 @@ end
 
 function handle_text(logic::ClientLogic, frame::Frame)
 	if frame.fin
-		on_text(logic.handler, utf8(frame.payload))
+		on_text(logic.handler, String(frame.payload))
 	else
 		start_buffer(logic, frame.payload, OPCODE_TEXT)
 	end
@@ -246,7 +248,7 @@ function handle_continuation(logic::ClientLogic, frame::Frame)
 	buffer(logic, frame.payload)
 	if frame.fin
 		if logic.buffered_type == OPCODE_TEXT
-			on_text(logic.handler, utf8(logic.buffer))
+			on_text(logic.handler, String(logic.buffer))
 		elseif logic.buffered_type == OPCODE_BINARY
 			on_binary(logic.handler, logic.buffer)
 			logic.buffer = Vector{UInt8}()
@@ -270,7 +272,7 @@ end
 function masking!(input::Vector{UInt8}, mask::Vector{UInt8})
 	m = 1
 	for i in 1:length(input)
-		input[i] = input[i] $ mask[(m - 1) % 4 + 1]
+		input[i] = input[i] ⊻ mask[(m - 1) % 4 + 1]
 		m += 1
 	end
 end

--- a/src/handshake.jl
+++ b/src/handshake.jl
@@ -1,16 +1,17 @@
+using Compat
 import Nettle
 import Requests
 
 "Keeps the result of a HTTP Upgrade attempt, when converting a HTTP connection to a WebSocket."
 immutable HandshakeResult
     # The expected `Sec-WebSocket-Accept` value. See `validate`.
-    expected_accept::ASCIIString
+    expected_accept::Compat.ASCIIString
 
     # The network stream opened by Requests, that we'll use for the WebSocket protocol.
     stream::IO
 
     # Response headers, keeping the WebSocket accept value, among others.
-    headers::Dict{ASCIIString,ASCIIString}
+    headers::Dict{Compat.ASCIIString,Compat.ASCIIString}
 
     # When doing the HTTP upgrade, we might have read a part of the first WebSocket frame. This
     # contains that data.
@@ -53,14 +54,14 @@ function make_websocket_key(rng::AbstractRNG)
 end
 
 "Calculate the accept value, given the random key supplied by the client."
-function calculate_accept(key::ASCIIString)
+function calculate_accept(key::Compat.ASCIIString)
     magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
     h = Nettle.digest("sha1", key * magic)
     base64encode(h)
 end
 
 "Create headers used to upgrade the HTTP connection to a WebSocket connection."
-function make_headers(key::ASCIIString)
+function make_headers(key::Compat.ASCIIString)
     headers = Dict(
         "Upgrade" => "websocket",
         "Connection" => "Upgrade",

--- a/src/reconnect.jl
+++ b/src/reconnect.jl
@@ -7,6 +7,7 @@
 # longer or shorter.
 
 import Base: reset
+using Compat
 
 export AbstractBackoff, Backoff, RandomizedBackoff, reset, backoff_min, backoff_max
 export AbstractRetry, Retry, retry, set_function
@@ -29,7 +30,7 @@ backoff_min(b::Backoff) = b.min
 backoff_max(b::Backoff) = b.max
 
 "Get the next backoff value."
-function call(b::Backoff)
+@compat function (b::Backoff)()
     v = b.min + atan(b.state*b.state/32) * 2 / pi * (b.max - b.min)
     b.state += 1
     v
@@ -48,7 +49,7 @@ reset(b::RandomizedBackoff) = reset(b.backoff)
 backoff_min(b::RandomizedBackoff) = backoff_min(b.backoff)
 backoff_max(b::RandomizedBackoff) = backoff_max(b.backoff)
 
-function call(b::RandomizedBackoff)
+@compat function (b::RandomizedBackoff)()
     (r,) = (rand(b.rng, Float64, 1) - 0.5) * 2 * b.interval
     v = b.backoff()
     max(backoff_min(b), min(backoff_max(b), v + r))


### PR DESCRIPTION
I didn't touch the test files, as I'm unable to run them right now. (I don't have FactCheck installed.)